### PR TITLE
修复stopwords_file文件路径错误

### DIFF
--- a/app/analysis/analysis.py
+++ b/app/analysis/analysis.py
@@ -34,7 +34,7 @@ def wordcloud(wxid, is_Annual_report=False, year='2023'):
     # 统计词频
     word_count = Counter(words)
     # 过滤停用词
-    stopwords_file = './app000/data/stopwords.txt'
+    stopwords_file = './app/data/stopwords.txt'
     try:
         with open(stopwords_file, "r", encoding="utf-8") as stopword_file:
             stopwords = set(stopword_file.read().splitlines())


### PR DESCRIPTION
stopwords_file文件路径有误
![BT1891_7YZ1AE01}~U)O@`E](https://github.com/LC044/WeChatMsg/assets/32475719/7f928e74-62bb-4da2-ad4c-b6bb78047439)
![K6C{ Q 8(G89XD1$9$51OT1](https://github.com/LC044/WeChatMsg/assets/32475719/32b31be2-5035-4f94-b9e8-7f333cf503bd)
