### PR TITLE
对python3.8以下做语法支持

### DIFF
--- a/app/util/emoji.py
+++ b/app/util/emoji.py
@@ -8,6 +8,8 @@ emoji.py
 所以禁止任何人以任何方式修改或间接修改该文件，违者后果自负
 """
 
+from typing import Union
+
 import os
 import traceback
 import xml.etree.ElementTree as ET
@@ -93,7 +95,7 @@ class Emotion:
                 if lock.locked():
                     lock.release()
 
-    def get_emoji_url(self, md5: str, thumb: bool) -> str | bytes:
+    def get_emoji_url(self, md5: str, thumb: bool) -> Union[str, bytes]:
         '''供下载用，返回可能是url可能是bytes'''
         if thumb:
             sql = '''


### PR DESCRIPTION
`str | bytes`这种语法是python3.10的语法，但是还有很多人用的是python3.8，这样就会报错。

使用typing的union是个通用办法，但是代码嘛，emmm，不会那么美观。

不知道你们的想法怎么样？