### PR TITLE
添加音乐和音频类型的html支持

### DIFF
--- a/app/resources/data/template.html
+++ b/app/resources/data/template.html
@@ -209,6 +209,86 @@ audio{
 .chat-file a img,.chat-file div img{
     width: 100px;
 }
+
+.chat-music-audio {
+    width: 300px;
+    margin-right: 20px;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    background-color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+    height: 100px;
+    margin-left: 10px;
+}
+
+.chat-music-audio .player-box {
+    width: 300px;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    height: 80px;
+}
+
+.chat-music-audio .player-original {
+    border-top: 1px solid #ede3e3;
+}
+
+.chat-music-audio .player-original p {
+    margin-top: 5px;
+    color: #888;
+}
+
+.chat-music-audio .player-controls {
+    display: flex;
+    align-items: center;;
+}
+
+.chat-music-audio .flex1 {
+    flex: 1;
+    justify-content: start;
+}
+
+.chat-music-audio .flex2 {
+    flex: 2;
+    justify-content: end;
+}
+
+.chat-music-audio .player-info {
+    width: 200px;
+    height: 80px;
+    white-space: normal;
+    flex-basis: 200px;
+}
+
+.chat-music-audio .song-title {
+    font-weight: bold;
+    overflow-wrap: break-word;
+}
+
+.chat-music-audio .artist {
+    margin-top: 10px;
+    color: #888;
+}
+
+.chat-music-audio .play-button {
+    width: 50px;
+    height: 50px;
+    background-color: rgba(0, 0, 0, 0);
+    border-radius: 50%;
+    border: none;
+    outline: none;
+    cursor: pointer;
+}
+
+.chat-music-audio .play-button.playing {
+    background: url("./icon/pause.png");
+}
+
+.chat-music-audio .play-button.paused {
+    background: url("./icon/play.png");
+}
 .input-area{
     border-top:0.5px solid #e0e0e0;
     height: 150px;
@@ -619,6 +699,53 @@ input {
             return messageFileTag;
         }
 
+        function messageMusicAudioBox(message) {
+            const messageMusicAudioTag = document.createElement('div');
+            messageMusicAudioTag.className = `chat-music-audio`;
+            messageMusicAudioTag.dataset.link = message.link_url;
+            messageMusicAudioTag.onclick = function (event) {
+                if (!event.target.classList.contains('play-button')) {
+                    window.open(message.link_url, '_blank');
+                }
+            }
+            if (message.title.length >= 39) {
+                message.title = message.title.slice(0, 38) + '...'
+            }
+            messageMusicAudioTag.innerHTML = `<div class="player-box">
+                <div class="player-info flex1">
+                    <div class="song-title">${message.title}</div>
+                </div>
+                <div class="player-controls flex2">
+                </div>
+                </div>
+                <div class="player-original"><p>${message.website_name}</p></div>
+
+                `
+            if (message.text != '') {
+                var audio = document.createElement('audio');
+                audio.src = message.text;
+                messageMusicAudioTag.querySelector('.player-controls').append(audio)
+            };
+            var artist = document.createElement('div');
+            artist.className = 'artist';
+            artist.innerHTML = message.artist
+            if (message.title.length < 26) {
+                messageMusicAudioTag.querySelector('.player-info').append(artist)
+            }
+            var playButton = document.createElement('button');
+            playButton.className = 'play-button paused';
+            playButton.onclick = function (event) {
+                event.stopPropagation(); // 阻止点击播放按钮时触发父级的点击事件
+                toggleAudio(event.target);
+            };
+            if (message.is_send) {
+                messageMusicAudioTag.querySelector('.player-controls').append(playButton)
+            } else {
+                messageMusicAudioTag.querySelector('.player-controls').prepend(playButton)
+            }
+            return messageMusicAudioTag;
+        }
+
             // 从数据列表中取出对应范围的元素并添加到容器中
         for (let i = startIndex; i < endIndex && i < chatMessages.length; i++) {
             const message = chatMessages[i];
@@ -721,6 +848,20 @@ input {
                     messageElement.appendChild(message.is_send ? messageContent : avatarTag);
                     messageElement.appendChild(message.is_send ? avatarTag : messageContent);
                 }
+                 if (message.sub_type == 3) {
+                    // displayname 和 file
+                    messageContent.className = `content-wrapper content-wrapper-${side}`;
+                    if (message.is_chatroom && !message.is_send) {
+                        messageContent.appendChild(displayNameBox(message));
+                    }
+                    messageContent.appendChild(messageMusicAudioBox(message));
+
+                    // 整合
+                    messageElement.className = `item item-${side}`;
+                    messageElement.appendChild(message.is_send ? messageContent : avatarTag);
+                    messageElement.appendChild(message.is_send ? avatarTag : messageContent);
+                }
+
             }
             else if (message.type == 34) {
                 // displayname 和 转的文字 和 audio
@@ -843,6 +984,26 @@ input {
     function hideModal() {
         var modal = document.getElementById("modal");
         modal.style.display = "none";
+    }
+
+
+    function toggleAudio(buttonElm) {
+        var audioPlayer = buttonElm.parentNode;
+        var audio = audioPlayer.querySelector('audio');
+        if (audio == null){
+            alert("该音频已失效或无法直接播放，有需要请点击音频链接查看")
+        }else{
+            if (audio.paused) {
+            audio.play();
+            buttonElm.classList.remove('paused');
+            buttonElm.classList.add('playing');
+        } else {
+            audio.pause();
+            buttonElm.classList.remove('playing');
+            buttonElm.classList.add('paused');
+        }
+        }
+
     }
 </script>
 </body>

--- a/app/ui/contact/export_dialog.py
+++ b/app/ui/contact/export_dialog.py
@@ -12,6 +12,7 @@ types = {
     '语音': 34,
     '视频': 43,
     '表情包': 47,
+    '音乐与音频': 4903,
     '文件': 4906,
     '拍一拍等系统消息': 10000
 }
@@ -33,7 +34,7 @@ class ExportDialog(QDialog):
         if file_type == 'html':
             self.export_type = Output.HTML
             self.export_choices = {"文本": True, "图片": True, "语音": False, "视频": False, "表情包": False,
-                                   '文件': True,
+                                   '音乐与音频': False,'文件': False,
                                    '拍一拍等系统消息': True}  # 定义导出的数据类型，默认全部选择
         elif file_type == 'csv':
             self.export_type = Output.CSV
@@ -64,7 +65,7 @@ class ExportDialog(QDialog):
         layout.addWidget(self.time_label)
         self.notice_label = QLabel(self)
         self.notice_label.setText(
-            "注意:导出HTML时选择图片、视频、语音、表情包（特别是表情包）\n会导致大大影响导出速度，请合理选择导出的类型")
+            "注意:导出HTML时选择图片、视频、语音、文件、音乐与音频、表情包（特别是表情包）\n会导致大大影响导出速度，请合理选择导出的类型")
         layout.addWidget(self.notice_label)
         hlayout = QHBoxLayout(self)
         self.export_button = QPushButton("导出")

--- a/app/util/music.py
+++ b/app/util/music.py
@@ -1,0 +1,55 @@
+import os
+import traceback
+import shutil
+
+from app.log import log, logger
+from app.util.protocbuf.msg_pb2 import MessageBytesExtra
+import requests
+from urllib.parse import urlparse, parse_qs
+import re
+
+root_path = './data/music/'
+if not os.path.exists('./data'):
+    os.mkdir('./data')
+if not os.path.exists(root_path):
+    os.mkdir(root_path)
+
+
+class File:
+    def __init__(self):
+        self.open_flag = False
+
+
+def get_music_path(url, file_title, output_path=root_path) -> str:
+    try:
+        parsed_url = urlparse(url)
+        if '.' in parsed_url.path:
+            # 获取扩展名
+            file_extension = parsed_url.path.split('.')[-1]
+
+            pattern = r'[\\/:*?"<>|\r\n]+'
+            file_title = re.sub(pattern, "_", file_title)
+            file_name = file_title + '.' + file_extension
+            music_path = os.path.join(output_path, file_name)
+            if os.path.exists(music_path):
+                # print('文件' + music_path + '已存在')
+                return music_path
+            header = {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.40 Safari/537.36 Edg/87.0.664.24'
+            }
+            requests.packages.urllib3.disable_warnings()
+            response = requests.get(url,headers=header,verify=False)
+            if response.status_code == 200:
+                with open(music_path, 'wb') as f:
+                    f.write(response.content)
+            else:
+                music_path = ''
+                print("音乐" + file_name + "获取失败：请求地址：" + url)
+        else:
+            music_path = ''
+            print('音乐文件已失效，url：' + url)
+        return music_path
+    except Exception as e:
+        print(f"Get Music Path Error: {e}")
+        logger.error(traceback.format_exc())
+        return ""


### PR DESCRIPTION
添加音乐和音频类型的html播放和跳转支持，包含一些音乐软件和k歌类型（保留部分已失效音频显示），示例图如下：
![snipaste_20240101_020723](https://github.com/LC044/WeChatMsg/assets/17832044/82d2ea22-212c-4cc3-b1d5-cc203bf61e95)
