### PR TITLE
fix: 修复文件名中有单引号导致导出html不显示所有聊天记录的问题

### DIFF
--- a/app/DataBase/exporter_html.py
+++ b/app/DataBase/exporter_html.py
@@ -16,6 +16,7 @@ from app.util.compress_content import parser_reply, share_card, music_share, fil
 from app.util.emoji import get_emoji_url
 from app.util.image import get_image_path, get_image
 from app.util.music import get_music_path
+from app.util.file import escape_single_quotes
 
 
 icon_files = {
@@ -127,10 +128,12 @@ class HtmlExporter(ExporterBase):
             file_path = file_info.get('file_path')
             if file_path != "":
                 file_path = './file/' + file_info.get('file_name')
+            file_path = escape_single_quotes(file_path)
+            file_name = escape_single_quotes(file_info.get('file_name'))
             doc.write(
                 f'''{{ type:49, text: '{file_path}',is_send:{is_send},avatar_path:'{avatar}',timestamp:{timestamp}
                             ,is_chatroom:{is_chatroom},displayname:'{display_name}',icon_path: '{icon_path}'
-                            ,sub_type:6,file_name: '{file_info.get('file_name')}',file_size: '{file_info.get('file_len')}'
+                            ,sub_type:6,file_name: '{file_name}',file_size: '{file_info.get('file_len')}'
                             ,app_name: '{file_info.get('app_name')}'}},'''
             )
 

--- a/app/util/file.py
+++ b/app/util/file.py
@@ -57,3 +57,6 @@ def get_file(bytes_extra, file_name, output_path=root_path) -> str:
     except:
         logger.error(traceback.format_exc())
         return ""
+
+def escape_single_quotes(path_str:str) -> str:
+    return path_str.replace("'",r"\'")


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
file_name使用的是单引号，
当文件名中有单引号时，导出的html文件会因为单引号截断，导致整个导出的html页面无法显示聊天记录
对应下面的这种情况，
![image](https://github.com/LC044/WeChatMsg/assets/36805478/78b9c1ec-11ee-4de5-80a7-ade90c4ad0f3)
需要将其中的单引号进行转义，变成
![image](https://github.com/LC044/WeChatMsg/assets/36805478/fdb62b13-67e2-4ce6-9354-5b5e15fe9002)

被单引号异常截断的html显示会变成下面的样子：
![image](https://github.com/LC044/WeChatMsg/assets/36805478/cf1233ff-9d84-41d0-b8ea-34011f230dc8)
控制台报错：
![image](https://github.com/LC044/WeChatMsg/assets/36805478/e7eae794-29a6-47cd-9597-a769d239e445)
报错对应的位置正是单引号异常截断的位置

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
