### PR TITLE
加快docx导出速度、更详细的过程输出

### DIFF
--- a/app/DataBase/exporter_csv.py
+++ b/app/DataBase/exporter_csv.py
@@ -23,7 +23,7 @@ class CSVExporter(ExporterBase):
             for msg in messages:
                 other_data = [msg[12].remark, msg[12].nickName, msg[12].wxid] if self.contact.is_chatroom else []
                 writer.writerow([*msg[:9], *other_data])
-        self.okSignal.emit('ok')
+        self.okSignal.emit(1)
 
     def run(self):
         self.to_csv()

--- a/app/DataBase/exporter_csv.py
+++ b/app/DataBase/exporter_csv.py
@@ -7,6 +7,7 @@ from app.DataBase.output import ExporterBase
 
 class CSVExporter(ExporterBase):
     def to_csv(self):
+        print("【开始导出 CSV {self.contact.remark}】")
         origin_docx_path = f"{os.path.abspath('.')}/data/聊天记录/{self.contact.remark}"
         os.makedirs(origin_docx_path, exist_ok=True)
         filename = f"{os.path.abspath('.')}/data/聊天记录/{self.contact.remark}/{self.contact.remark}_utf8.csv"
@@ -23,6 +24,7 @@ class CSVExporter(ExporterBase):
             for msg in messages:
                 other_data = [msg[12].remark, msg[12].nickName, msg[12].wxid] if self.contact.is_chatroom else []
                 writer.writerow([*msg[:9], *other_data])
+        print("【完成导出 CSV {self.contact.remark}】")
         self.okSignal.emit(1)
 
     def run(self):

--- a/app/DataBase/exporter_docx.py
+++ b/app/DataBase/exporter_docx.py
@@ -282,7 +282,7 @@ class DocxExporter(ExporterBase):
         middle_new_docx.save(origin_docx_path + '/' + filename)
 
     def export(self):
-        print('导出docx')
+        print(f"【开始导出 DOCX {self.contact.remark}】")
         origin_docx_path = f"{os.path.abspath('.')}/data/聊天记录/{self.contact.remark}"
         filename = os.path.join(origin_docx_path, f"{self.contact.remark}.docx")
         doc = docx.Document()
@@ -327,9 +327,11 @@ class DocxExporter(ExporterBase):
                 self.refermsg(doc, message)
             elif type_ == 49 and sub_type == 6 and self.message_types.get(4906):
                 self.file(doc, message)
+            print(f"【导出 DOCX {self.contact.remark}】{index}/{len(messages)}")
         try:
             doc.save(filename)
         except PermissionError:
             filename = filename[:-5] + f'{time.time()}' + '.docx'
             doc.save(filename)
+        print(f"【完成导出 DOCX {self.contact.remark}】")
         self.okSignal.emit(1)

--- a/app/DataBase/exporter_html.py
+++ b/app/DataBase/exporter_html.py
@@ -275,6 +275,7 @@ class HtmlExporter(ExporterBase):
         )
 
     def export(self):
+        print(f"【开始导出 HTML {self.contact.remark}】")
         messages = msg_db.get_messages(self.contact.wxid, time_range=self.time_range)
         filename = f"{os.path.abspath('.')}/data/聊天记录/{self.contact.remark}/{self.contact.remark}.html"
         file_path = './app/resources/data/template.html'
@@ -318,8 +319,11 @@ class HtmlExporter(ExporterBase):
                 self.music_share(f, message)
             elif type_ == 49 and sub_type == 5 and self.message_types.get(4905):
                 self.share_card(f, message)
+            if index % 2000 == 0:
+                print(f"【导出 HTML {self.contact.remark}】{index}/{len(messages)}")
         f.write(html_end)
         f.close()
+        print(f"【完成导出 HTML {self.contact.remark}】{len(messages)}")
         self.count_finish_num(1)
 
     def count_finish_num(self, num):

--- a/app/DataBase/exporter_txt.py
+++ b/app/DataBase/exporter_txt.py
@@ -110,6 +110,7 @@ class TxtExporter(ExporterBase):
 
     def export(self):
         # 实现导出为txt的逻辑
+        print("【开始导出 TXT {self.contact.remark}】")
         origin_docx_path = f"{os.path.abspath('.')}/data/聊天记录/{self.contact.remark}"
         os.makedirs(origin_docx_path, exist_ok=True)
         filename = f"{os.path.abspath('.')}/data/聊天记录/{self.contact.remark}/{self.contact.remark}.txt"
@@ -140,4 +141,5 @@ class TxtExporter(ExporterBase):
                     self.music_share(f, message)
                 elif type_ == 49 and sub_type == 5 and self.message_types.get(4905):
                     self.share_card(f, message)
+        print("【完成导出 TXT {self.contact.remark}】")
         self.okSignal.emit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ soupsieve==2.5
 lz4==4.3.2
 pilk==0.2.4
 python-docx==1.1.0
+docxcompose==1.4.0
 eyed3==0.9.7


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

1. 在导出过程中，添加更多运行过程输出，以便用户了解运行状态。
2. 对于 docx 导出，原本为每一条记录追加一次，改为每200条一组再合并。增加依赖库 docxcompose。
3. 顺便修复 CSV 导出结束 okSignal 的值。

#### 📝 补充信息 | Additional Information

1. 之前我在使用软件时，因为一份对话过多，导出时间太长了，进度条一直在99%，无法确定是程序卡了还是在处理中。于是，我为一些耗时的处理添加了过程输出，这样用户就可以知道程序在运行，而不是报错卡了。 

2. 对于一次共22736条消息的导出，新的 docx 导出方法用173s完成整个导出，而原版在200s时仅完成了5625条，大概四分之一，并且越来越慢。
（↓这是原版↓）
![image](https://github.com/LC044/WeChatMsg/assets/36418285/eac5947c-41c4-4ff6-94f6-0a6deae2dc7c)

3. `okSignal = pyqtSignal(int)`，因此 emit 1 而不是 'ok'。